### PR TITLE
fix(cmds/setpermissionlevel): Command parameters are no longer optional

### DIFF
--- a/src/commands/setpermissionlevel.go
+++ b/src/commands/setpermissionlevel.go
@@ -22,11 +22,14 @@ func (c SetPermissionLevelCommand) getCommandData() *discordgo.ApplicationComman
 				Type:        discordgo.ApplicationCommandOptionUser,
 				Name:        "user",
 				Description: "The user to set the permission level of.",
+				Required:    true,
+
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionInteger,
 				Name:        "level",
 				Description: "The permission level to set the user to.",
+				Required:    true,
 				Choices: []*discordgo.ApplicationCommandOptionChoice{
 					{
 						Name:  "User",


### PR DESCRIPTION
Fixes a crash when the command is blank